### PR TITLE
Update play-services-wallet version to prevent build error

### DIFF
--- a/src/android/build-extras.gradle
+++ b/src/android/build-extras.gradle
@@ -9,7 +9,7 @@ android {
 
 dependencies {
     compile 'com.braintreepayments.api:drop-in:3.+'
-    compile 'com.google.android.gms:play-services-wallet:+'
+    compile 'com.google.android.gms:play-services-wallet:15.0.1'
     compile 'io.card:android-sdk:5.5.1'
 }
 


### PR DESCRIPTION
This will allow this plugin to play nice with phonegap-plugin-push version 2+ and prevent a build error.

The newer version of phonegap brings in play services dependencies with specific versions while the braintree plugin just specifies “+”. Java doesn’t like this when building the app and gives an error of `Gradle sync failed: For input string: "+"` Here’s a stackoverflow post of someone who also encountered this: https://stackoverflow.com/questions/44778247/gradle-sync-failed-for-input-string 

I could probably scrounge up something more official if needed as well.